### PR TITLE
Ajuste no looping das tags

### DIFF
--- a/wp-content/themes/sme-portal-institucional/classes/TemplateHierarchy/Tag.php
+++ b/wp-content/themes/sme-portal-institucional/classes/TemplateHierarchy/Tag.php
@@ -18,7 +18,7 @@ class PaginaTag{
 			'post_type' => 'post',
 			'post_status' => 'publish',
 			'taxonomy'	=> 'post_tag',
-			'tag' => $get_term_name,
+			'tag__in' => $term_id,
 			'posts_per_page' => 12,
 			'paged' => $paged,
 		);


### PR DESCRIPTION
Ajuste no looping de notícias baseado nas tags alterando a busca de nome da tag para o id da tag