### PR TITLE
Padrao para imagens destacadas

### DIFF
--- a/wp-content/themes/sme-portal-institucional/classes/ModelosDePaginas/Layout/construtor.php
+++ b/wp-content/themes/sme-portal-institucional/classes/ModelosDePaginas/Layout/construtor.php
@@ -483,19 +483,12 @@ if( have_rows('fx_flex_layout') ):
 															foreach($slidesNoticias as $slide): ?>
 																<div class="carousel-item <?php if($l == 0){echo 'active';} ?>">
 																	<div class="row">
-																		<div class="col-sm-12 col-md-7">
+																		<div class="col-sm-7">
 																			<?php                                                 
-																				 $imgSelect = get_the_post_thumbnail_url($slide, 'slide-noticias');
-																				 
-																				 $featured_img_url =  $imgSelect;
-																				 
-																				 if($featured_img_url){
-																					 $imgSlide =  $imgSelect;
-																				 } else {
-																					 $imgSlide = 'http://via.placeholder.com/656x304';
-																				 }                                               
+																				// Busca a imagem destaca / primeira imagem / imagem padrao -- functions.php
+																				$thumbs = get_thumb($slide);                                            
 																			?>
-																			<a href="<?php echo get_the_permalink($slide); ?>"><img class="d-block w-100" src="<?php echo  $imgSlide; ?>" alt="Slide "></a>
+																			<a href="<?php get_the_permalink($slide); ?>"><img class="d-block w-100" src="<?php echo $thumbs[0]; ?>" alt="<?php echo $thumbs[1]; ?>"></a>
 																		</div>
 																		<div class="col-sm-12 col-md-5"> 
 																			<div class="carousel-title">
@@ -648,27 +641,14 @@ if( have_rows('fx_flex_layout') ):
 											if($blocoNoticias) :
 
 												foreach($blocoNoticias as $noticia):
-																									
-													$imgSelect = get_the_post_thumbnail_url($noticia, 'slide-noticias');
-													$thumbnail_id = get_post_thumbnail_id( $noticia );
-													$alt = get_post_meta($thumbnail_id, '_wp_attachment_image_alt', true); 
 													
-													$featured_img_url =  $imgSelect;
-													
-													if($featured_img_url){
-														$imgSlide =  $imgSelect;
-														if(!$alt){
-															$alt = get_the_title();
-														}
-													} else {
-														$imgSlide = 'http://via.placeholder.com/656x304';
-														$alt = get_the_title();
-													}                                               
+													// Busca a imagem destaca / primeira imagem / imagem padrao -- functions.php
+													$thumbs = get_thumb($noticia);
 											
 												?>
 													<div class="col-sm-12 col-md-6 col-lg-<?php echo $blocoColunas; ?> lista-noticia">
 														<a href="<?php echo get_the_permalink($noticia); ?>">
-															<img src="<?php echo $imgSlide; ?>" alt="<?php echo $alt; ?>" class="img-fluid">
+															<img src="<?php echo $thumbs[0]; ?>" alt="<?php echo $thumbs[1]; ?>" class="img-fluid">
 															<p><?php echo get_the_title($noticia); ?></p>
 														</a>
 													</div>

--- a/wp-content/themes/sme-portal-institucional/classes/ModelosDePaginas/PaginaMaisNoticias/PaginaMaisNoticiasDestaques.php
+++ b/wp-content/themes/sme-portal-institucional/classes/ModelosDePaginas/PaginaMaisNoticias/PaginaMaisNoticiasDestaques.php
@@ -20,11 +20,15 @@ class PaginaMaisNoticiasDestaques extends PaginaMaisNoticias
 					<?php
 						$posts = get_field('primeiro_destaque','option');
 							if( $posts ): ?>
-								<?php foreach( $posts as $p ): ?>
+								<?php foreach( $posts as $p ): 
+
+									// Busca a imagem destaca / primeira imagem / imagem padrao -- functions.php
+									$thumbs = get_thumb($p->ID); 
+								?>
 									<session class="card text-white mb-3">
 									
 									<figure class="m-0 p-0">
-										<img src="<?php echo get_the_post_thumbnail_url( $p->ID ); ?>" width="100%">
+										<img src="<?php echo $thumbs[0]; ?>" alt="<?php echo $thumbs[1]; ?>" width="100%">
 									</figure>
 									<article class="overlay-noticia d-flex flex-column justify-content-end">
 										<h2 class="card-title mais-noticias-destaque-principal"><a href="<?php echo get_permalink( $p->ID ); ?>">
@@ -54,8 +58,11 @@ class PaginaMaisNoticiasDestaques extends PaginaMaisNoticias
 					<?php
 						$posts = get_field('segundo_destaque','option');
 							if( $posts ): ?>
-								<?php foreach( $posts as $p ): ?>
-									<div class="mb-4"><img src="<?php echo get_the_post_thumbnail_url( $p->ID ); ?>" width="100%"></div>
+								<?php foreach( $posts as $p ):
+									// Busca a imagem destaca / primeira imagem / imagem padrao -- functions.php
+									$thumbs = get_thumb($p->ID); 
+								?>
+									<div class="mb-4"><img src="<?php echo $thumbs[0]; ?>" alt="<?php echo $thumbs[1]; ?>>"width="100%"></div>
 									<div class="mb-4"><a href="<?php echo get_permalink( $p->ID ); ?>">
 										<h2 class="card-title mais-noticias-titulo-destaque-secundarios"><?php echo get_the_title( $p->ID ); ?></h2>
 									</a></div>
@@ -68,8 +75,11 @@ class PaginaMaisNoticiasDestaques extends PaginaMaisNoticias
 					<?php
 						$posts = get_field('terceiro_destaque','option'); 
 							if( $posts ): ?>
-								<?php foreach( $posts as $p ): ?>
-									<div class="mb-4"><img src="<?php echo get_the_post_thumbnail_url( $p->ID ); ?>" width="100%"></div>
+								<?php foreach( $posts as $p ):
+									// Busca a imagem destaca / primeira imagem / imagem padrao -- functions.php
+									$thumbs = get_thumb($p->ID); 
+								?>
+									<div class="mb-4"><img src="<?php echo $thumbs[0]; ?>" alt="<?php echo $thumbs[1]; ?>>"width="100%"></div>
 									<div class="mb-4"><a href="<?php echo get_permalink( $p->ID ); ?>">
 										<h2 class="card-title mais-noticias-titulo-destaque-secundarios"><?php echo get_the_title( $p->ID ); ?></h2>
 									</a></div>
@@ -84,8 +94,11 @@ class PaginaMaisNoticiasDestaques extends PaginaMaisNoticias
 					<?php
 						$posts = get_field('quarto_destaque','option');
 							if( $posts ): ?>
-								<?php foreach( $posts as $p ): ?>
-									<div class="mb-4"><img src="<?php echo get_the_post_thumbnail_url( $p->ID ); ?>" width="100%"></div>
+								<?php foreach( $posts as $p ):
+									// Busca a imagem destaca / primeira imagem / imagem padrao -- functions.php
+									$thumbs = get_thumb($p->ID); 
+								?>
+									<div class="mb-4"><img src="<?php echo $thumbs[0]; ?>" alt="<?php echo $thumbs[1]; ?>>"width="100%"></div>
 									<div class="mb-4"><a href="<?php echo get_permalink( $p->ID ); ?>">
 										<h2 class="card-title mais-noticias-titulo-destaque-secundarios"><?php echo get_the_title( $p->ID ); ?></h2>
 									</a></div>
@@ -98,8 +111,11 @@ class PaginaMaisNoticiasDestaques extends PaginaMaisNoticias
 					<?php
 						$posts = get_field('quinto_destaque','option');
 							if( $posts ): ?>
-								<?php foreach( $posts as $p ): ?>
-									<div class="mb-4"><img src="<?php echo get_the_post_thumbnail_url( $p->ID ); ?>" width="100%"></div>
+								<?php foreach( $posts as $p ):
+									// Busca a imagem destaca / primeira imagem / imagem padrao -- functions.php
+									$thumbs = get_thumb($p->ID); 
+								?>
+									<div class="mb-4"><img src="<?php echo $thumbs[0]; ?>" alt="<?php echo $thumbs[1]; ?>>"width="100%"></div>
 									<div class="mb-4"><a href="<?php echo get_permalink( $p->ID ); ?>">
 										<h2 class="card-title mais-noticias-titulo-destaque-secundarios"><?php echo get_the_title( $p->ID ); ?></h2>
 									</a></div>

--- a/wp-content/themes/sme-portal-institucional/classes/ModelosDePaginas/PaginaMaisNoticias/PaginaMaisNoticiasOutrasNoticias.php
+++ b/wp-content/themes/sme-portal-institucional/classes/ModelosDePaginas/PaginaMaisNoticias/PaginaMaisNoticiasOutrasNoticias.php
@@ -44,20 +44,19 @@ class PaginaMaisNoticiasOutrasNoticias extends PaginaMaisNoticias
             <section class="row mb-5">
                 <article class="col-lg-12">
 					<?php
-					$thumb = get_the_post_thumbnail_url($query->ID);
-					$url = get_the_permalink($query->ID);
-					$post_thumbnail_id = get_post_thumbnail_id( $query->ID );
-					$image_alt = get_post_meta( $post_thumbnail_id, '_wp_attachment_image_alt', true);
+
+					// Busca a imagem destaca / primeira imagem / imagem padrao -- functions.php
+					$thumbs = get_thumb($query->ID); 
 			
-					if ($thumb){
+					if ($thumbs){
 						echo '<figure class=" m-0">';
-						echo '<img src="'.$thumb.'" class="img-fluid rounded float-left mr-4 w-25" alt="'.$image_alt.'"/>';
+						echo '<img src="'.$thumbs[0].'" class="img-fluid rounded float-left mr-4 w-25" alt="'.$thumbs[1].'"/>';
 						echo '</figure>';
 					}
 					?>
 					<div class="grid-noticias">
                     <h4 class="fonte-dezoito font-weight-bold mb-2">
-                        <a class="text-decoration-none text-dark" href="<?= $url ?>">
+                        <a class="text-decoration-none text-dark" href="<?php echo get_the_permalink($query->ID); ?>">
 							<?= $query->post_title ?>
                         </a>
                     </h4>

--- a/wp-content/themes/sme-portal-institucional/classes/TemplateHierarchy/LoopSingle/LoopSingleRelacionadas.php
+++ b/wp-content/themes/sme-portal-institucional/classes/TemplateHierarchy/LoopSingle/LoopSingleRelacionadas.php
@@ -107,26 +107,22 @@ class LoopSingleRelacionadas extends LoopSingle
 		echo '<div class="col-sm-8"><h2>Relacionadas</h2>';
 		echo '<div class="row">';
 		while ( $the_query->have_posts() ) : $the_query->the_post();
+
+			// Busca a imagem destaca / primeira imagem / imagem padrao -- functions.php
+			$thumbs = get_thumb(get_the_ID());   
 		?>
 			
 			<div class="col-sm-4 mb-4">
-				<img class="rounded " src="<?php the_post_thumbnail_url( 'related-post' ); ?>" width="100%">			
+				<img src="<?php echo $thumbs[0]; ?>" alt="<?php echo $thumbs[1]; ?>" class="img-fluid rounded">			
 			</div>
 			<div class="col-sm-8 mb-4">
 				<h3 class="fonte-dezoito font-weight-bold mb-2">
-					<a class="text-decoration-none text-dark" href="<?php the_permalink(); ?>">
+					<a class="text-decoration-none text-dark" href="<?php echo get_the_permalink($query->ID); ?>">
 						<?php the_title(); ?>
 					</a>
 				</h3>
 				<?php
-				//echo $this->getSubtitulo($query->ID, 'p', 'fonte-dezesseis mb-2')
-				?>
-				<?php
-					if(get_field('insira_o_subtitulo', $query->ID) != ''){
-						the_field('insira_o_subtitulo', $query->ID);
-					}else if (get_field('insira_o_subtitulo', $query->ID) == ''){
-						 echo get_the_excerpt($query->ID); 
-					}
+				echo $this->getSubtitulo($query->ID, 'p', 'fonte-dezesseis mb-2')
 				?>
 				<?= $this->getComplementosRelacionadas($query->ID); ?>
 				


### PR DESCRIPTION
- Padronização de tamanho das imagens destacadas das noticias;
- Se não houver imagem destacada será pego a primeira imagem dentro da publicação;
- Não tendo nenhuma das duas imagens acima será inserido uma imagem padrão com logo da prefeitura.