### PR TITLE
Alteracao cadastro de eventos

### DIFF
--- a/wp-content/themes/tema-ceus/classes/Breadcrumb/Breadcrumb.php
+++ b/wp-content/themes/tema-ceus/classes/Breadcrumb/Breadcrumb.php
@@ -88,25 +88,21 @@ class Breadcrumb
 
 				}
 
-				// Get post category info
-				$category = get_the_category();
+				// Pega a unidade do evento
+				
+				$local = get_field('localizacao', get_the_ID()); 
 
-				if(!empty($category)) {
-
-					// Get last category post is in
-					$last_category = end(array_values($category));
-
-					// Get parent any categories and create array
-					$get_cat_parents = rtrim(get_category_parents($last_category->term_id, true, ','),',');
-					$cat_parents = explode(',',$get_cat_parents);
-
+				if(!empty($local)) {
 					// Loop through parent categories and store in variable $cat_display
 					$cat_display = '';
-					foreach($cat_parents as $parents) {
-						$cat_display .= '<li class="item-cat">'.$parents.'</li>';
-						$cat_display .= '<li class="separator"> ' . $this->separator . ' </li>';
-					}
 
+					if($local == '31675' || $local == '31244'){
+						$cat_display .= '<li class="item-cat">'.get_the_title($local).'</li>';
+					} else {
+						$cat_display .= '<li class="item-cat"><a href="' . get_the_permalink($local) . '">'.get_the_title($local).'</a></li>';
+					}
+					
+					$cat_display .= '<li class="separator"> ' . $this->separator . ' </li>';
 				}
 
 				// If it's a custom post type within a custom taxonomy
@@ -122,7 +118,7 @@ class Breadcrumb
 				}
 
 				// Check if the post is in a category
-				if(!empty($last_category)) {
+				if(!empty($local)) {
 					echo $cat_display;
 					echo '<li class="item-current item-' . $post->ID . '"><strong class="bread-current bread-' . $post->ID . '" >' . get_the_title() . '</strong></li>';
 

--- a/wp-content/themes/tema-ceus/classes/ModelosDePaginas/PaginaProgramacao/PaginaProgramacaoBusca.php
+++ b/wp-content/themes/tema-ceus/classes/ModelosDePaginas/PaginaProgramacao/PaginaProgramacaoBusca.php
@@ -101,9 +101,32 @@ class PaginaProgramacaoBusca
 
                         <div class="col-sm-3 mt-3 px-1">
                             <select name="unidades[]" multiple="multiple" class="ms-list-5" style="">
-                                <?php foreach ($unidades as $unidade): ?>
-                                    <option value="<?php echo $unidade->term_id; ?>"><?php echo $unidade->name; ?></option>
-                                <?php endforeach; ?>     
+                                <?php
+                                        $currentID = get_the_id();
+                                        $argsUnidades = array(
+                                            'post_type' => 'unidade',
+                                            'posts_per_page' => -1,
+                                            'post__not_in' => array(31675, 31244),
+                                        );
+
+                                        $todasUnidades = new \WP_Query( $argsUnidades );
+                
+                                        // The Loop
+                                        if ( $todasUnidades->have_posts() ) {
+                                            
+                                            while ( $todasUnidades->have_posts() ) {
+                                                $todasUnidades->the_post();
+                                                if($currentID == get_the_id() ) {
+                                                    echo '<option selected value="' . get_the_id() .'">' . get_the_title() .'</option>';
+                                                } else {
+                                                    echo '<option value="' . get_the_id() .'">' . get_the_title() .'</option>';
+                                                }
+                                                
+                                            }
+                                        
+                                        }
+                                        wp_reset_postdata();
+                                    ?>      
                             </select>
                         </div>
 
@@ -135,9 +158,9 @@ class PaginaProgramacaoBusca
 
                         <div class="col-sm-3 mt-3 px-1">
                             <select name="periodos[]" multiple="multiple" class="ms-list-8" style="">                        
-                                <?php foreach ($periodos as $periodo): ?>
-                                    <option value="<?php echo $periodo->term_id; ?>"><?php echo $periodo->name; ?></option>
-                                <?php endforeach; ?>                        
+                                <option value='manha'>Manhã</option>
+                                <option value='tarde'>Tarde</option>
+                                <option value='noite'>Noite</option>                        
                             </select>
                         </div>
                         <div class="col-sm-12 text-right mt-3">

--- a/wp-content/themes/tema-ceus/classes/ModelosDePaginas/PaginaProgramacao/PaginaProgramacaoEventos.php
+++ b/wp-content/themes/tema-ceus/classes/ModelosDePaginas/PaginaProgramacao/PaginaProgramacaoEventos.php
@@ -42,7 +42,8 @@ class PaginaProgramacaoEventos
                                             //$featured_img_url = get_the_post_thumbnail_url($eventoInterno->ID, 'thumb-eventos');
                                             $imgSelect = get_field('capa_do_evento', $eventoInterno->ID);
                                             $tipo = get_field('tipo_de_evento_selecione_o_evento', $eventoInterno->ID);
-                                            
+                                            $online = get_field('tipo_de_evento_online', $eventoInterno->ID);
+
                                             $featured_img_url = wp_get_attachment_image_src($imgSelect, 'thumb-eventos');
                                             if($featured_img_url){
                                                 $imgEvento = $featured_img_url[0];
@@ -57,6 +58,15 @@ class PaginaProgramacaoEventos
                                         <?php if($tipo && $tipo != '') : 
                                             echo '<span class="flag-pdf-full">';
                                                 echo get_the_title($tipo);
+                                            echo '</span>';                                           
+                                        endif; ?>                                      
+
+                                        <?php if($online && $online != '') : 
+                                            if($tipo && $tipo != ''){
+                                                $customClass = 'mt-tags';
+                                            }
+                                            echo '<span class="flag-online flag-pdf-full ' . $customClass . '">';
+                                                echo "Evento Online";
                                             echo '</span>';
                                         endif; ?>
                                     </div>
@@ -232,9 +242,13 @@ class PaginaProgramacaoEventos
                                             <i class="fa fa-clock-o" aria-hidden="true"></i> <?php echo $hora; ?>
                                         </p>
                                         <?php
-                                            $local = get_field('localizacao', $eventoInterno->ID);
+                                            $local = get_field('localizacao', $eventoInterno->ID);                                                        
+                                            if($local == '31675' || $local == '31244'):
                                         ?>
-                                        <p class="mb-0 mt-1 evento-unidade"><a href="<?php echo get_the_permalink($local); ?>"><i class="fa fa-map-marker" aria-hidden="true"></i> <?php echo get_the_title($local); ?></a></p>
+                                            <p class="mb-0 mt-1 evento-unidade no-link"><i class="fa fa-map-marker" aria-hidden="true"><span>icone unidade</span></i> <?php echo get_the_title($local); ?></p>
+                                        <?php else: ?>
+                                            <p class="mb-0 mt-1 evento-unidade"><a href="<?php echo get_the_permalink($local); ?>"><i class="fa fa-map-marker" aria-hidden="true"><span>icone unidade</span></i> <?php echo get_the_title($local); ?></a></p>
+                                        <?php endif; ?>
                                     </div>
                                 </div>
                                 <?php 

--- a/wp-content/themes/tema-ceus/classes/ModelosDePaginas/PaginaProgramacao/PaginaProgramacaoSlide.php
+++ b/wp-content/themes/tema-ceus/classes/ModelosDePaginas/PaginaProgramacao/PaginaProgramacaoSlide.php
@@ -229,9 +229,13 @@ class PaginaProgramacaoSlide
                                                     <i class="fa fa-clock-o" aria-hidden="true"></i> <?php echo $hora; ?>
                                                 </p>
                                                 <?php
-                                                    $local = get_field('localizacao', $slide->ID);     
+                                                    $local = get_field('localizacao', $slide->ID);                                                        
+                                                    if($local == '31675' || $local == '31244'):
                                                 ?>
-                                                <p class="mb-0 mt-1 evento-unidade"><a href="<?php echo get_the_permalink($local); ?>"><i class="fa fa-map-marker" aria-hidden="true"></i> <?php echo get_the_title($local); ?></a></p>
+                                                    <p class="mb-0 mt-1 evento-unidade no-link"><i class="fa fa-map-marker" aria-hidden="true"><span>icone unidade</span></i> <?php echo get_the_title($local); ?></p>
+                                                <?php else: ?>
+                                                    <p class="mb-0 mt-1 evento-unidade"><a href="<?php echo get_the_permalink($local); ?>"><i class="fa fa-map-marker" aria-hidden="true"><span>icone unidade</span></i> <?php echo get_the_title($local); ?></a></p>
+                                                <?php endif; ?>
                                             </div>
                                         </div>
                                     </div>

--- a/wp-content/themes/tema-ceus/classes/ModelosDePaginas/PaginaUnidades/PaginaUnidadesMapa.php
+++ b/wp-content/themes/tema-ceus/classes/ModelosDePaginas/PaginaUnidades/PaginaUnidadesMapa.php
@@ -23,7 +23,7 @@ class PaginaUnidadesMapa
                     <?php
                         $args = array(
                             'post_type' => 'unidade',
-                            'post__not_in' => array(31202),
+                            'post__not_in' => array(31244, 31675),
                             'order' => 'ASC',
                             'orderby' => 'title',
                         );

--- a/wp-content/themes/tema-ceus/classes/TemplateHierarchy/LoopSingle/LoopSingleCabecalho.php
+++ b/wp-content/themes/tema-ceus/classes/TemplateHierarchy/LoopSingle/LoopSingleCabecalho.php
@@ -86,12 +86,15 @@ class LoopSingleCabecalho extends LoopSingle
 						?>
 
 						<p class="evento-unidade m-0 w-100">
-							<?php if($local == 31244): ?>
+							<?php
+								$local = get_field('localizacao', $post->ID);                                                        
+								if($local == '31675' || $local == '31244'):
+							?>
 								<?php echo get_the_title($local); ?>
 							<?php else: ?>
 								<a href="<?php echo get_the_permalink($local); ?>"><?php echo get_the_title($local); ?></a>
 							<?php endif; ?>
-                        </p>
+						</p>
                     </div>
                 </div>
             </div>

--- a/wp-content/themes/tema-ceus/classes/TemplateHierarchy/LoopSingle/LoopSingleNoticiaPrincipal.php
+++ b/wp-content/themes/tema-ceus/classes/TemplateHierarchy/LoopSingle/LoopSingleNoticiaPrincipal.php
@@ -195,9 +195,10 @@ class LoopSingleNoticiaPrincipal extends LoopSingle
 											<th scope="row" class="align-middle"><i class="fa fa-map-marker" aria-hidden="true"></i></th>
 											<?php if($local == 31244): ?>
 												<td><p class="m-0">Consulte abaixo CEUs participantes</p></td>
+											<?php elseif($local == 31675): ?>
+												<td><p class="m-0"><strong>Para toda a rede</strong></p></td>
 											<?php else: ?>
 												<td><strong><?php echo get_the_title($local); ?></strong>
-												
 												<?php 
 													$end = get_field('informacoes_basicas', $local);
 													

--- a/wp-content/themes/tema-ceus/classes/TemplateHierarchy/LoopSingle/LoopSingleRelacionadas.php
+++ b/wp-content/themes/tema-ceus/classes/TemplateHierarchy/LoopSingle/LoopSingleRelacionadas.php
@@ -54,6 +54,7 @@ class LoopSingleRelacionadas extends LoopSingle
 			$infosBasicas = get_field('informacoes_basicas', $local);
 			$zona = get_group_field( 'informacoes_basicas', 'zona_sp', $local );
 	?>
+		<?php if(!$local == '31675' || !$local == '31244'): ?>
 		<div class="end-footer py-4 col-12 color-<?php echo $zona; ?>">
             <div class="container">
                 <div class="row">
@@ -136,7 +137,7 @@ class LoopSingleRelacionadas extends LoopSingle
                 </div>
             </div>
 		</div>
-		
+		<?php endif; ?>		
 		<?php
 		else:
 
@@ -541,9 +542,13 @@ class LoopSingleRelacionadas extends LoopSingle
 												<i class="fa fa-clock-o" aria-hidden="true"></i> <?php echo $hora; ?>
 											</p>
 											<?php
-                                                $local = get_field('localizacao', get_the_ID());                                                
-                                            ?>
-                                            <p class="mb-0 mt-1 evento-unidade"><a href="<?php echo get_the_permalink($local); ?>"><i class="fa fa-map-marker" aria-hidden="true"><span>icone unidade</span></i> <?php echo get_the_title($local); ?></a></p>
+												$local = get_field('localizacao', get_the_ID());                                                        
+												if($local == '31675' || $local == '31244'):
+											?>
+												<p class="mb-0 mt-1 evento-unidade no-link"><i class="fa fa-map-marker" aria-hidden="true"><span>icone unidade</span></i> <?php echo get_the_title($local); ?></p>
+											<?php else: ?>
+												<p class="mb-0 mt-1 evento-unidade"><a href="<?php echo get_the_permalink($local); ?>"><i class="fa fa-map-marker" aria-hidden="true"><span>icone unidade</span></i> <?php echo get_the_title($local); ?></a></p>
+											<?php endif; ?>
 										</div>
 									</div>
 									<?php 

--- a/wp-content/themes/tema-ceus/classes/TemplateHierarchy/LoopUnidades/LoopUnidadesSlide.php
+++ b/wp-content/themes/tema-ceus/classes/TemplateHierarchy/LoopUnidades/LoopUnidadesSlide.php
@@ -228,9 +228,13 @@ class LoopUnidadesSlide extends LoopUnidades{
                                                 <i class="fa fa-clock-o" aria-hidden="true"><span>icone relogio</span></i> <?php echo $hora; ?>
                                             </p>
                                             <?php
-                                                $local = get_field('localizacao', $slide);                                                
+                                                $local = get_field('localizacao', $slide);                                                        
+                                                if($local == '31675' || $local == '31244'):
                                             ?>
-                                            <p class="mb-0 mt-1 evento-unidade"><a href="<?php echo get_the_permalink($local); ?>"><i class="fa fa-map-marker" aria-hidden="true"><span>icone unidade</span></i> <?php echo get_the_title($local); ?></a></p>
+                                                <p class="mb-0 mt-1 evento-unidade no-link"><i class="fa fa-map-marker" aria-hidden="true"><span>icone unidade</span></i> <?php echo get_the_title($local); ?></p>
+                                            <?php else: ?>
+                                                <p class="mb-0 mt-1 evento-unidade"><a href="<?php echo get_the_permalink($local); ?>"><i class="fa fa-map-marker" aria-hidden="true"><span>icone unidade</span></i> <?php echo get_the_title($local); ?></a></p>
+                                            <?php endif; ?>
                                         </div>
                                     </div>
                                 </div>

--- a/wp-content/themes/tema-ceus/classes/TemplateHierarchy/LoopUnidades/LoopUnidadesTabs.php
+++ b/wp-content/themes/tema-ceus/classes/TemplateHierarchy/LoopUnidades/LoopUnidadesTabs.php
@@ -177,10 +177,10 @@ class LoopUnidadesTabs extends LoopUnidades{
 
                                     <div class="col-sm-3 mt-3 px-1">
                                         <label for="periodos" class='d-none'>Escolha o tipo de data</label>
-                                        <select id="periodos" name="periodos[]" multiple="multiple" class="ms-list-8" style="">                        
-                                            <?php foreach ($periodos as $periodo): ?>
-                                                <option value="<?php echo $periodo->term_id; ?>"><?php echo $periodo->name; ?></option>
-                                            <?php endforeach; ?>                        
+                                        <select id="periodos" name="periodos[]" multiple="multiple" class="ms-list-8" style="">
+                                                <option value='manha'>Manhã</option>
+                                                <option value='tarde'>Tarde</option>
+                                                <option value='noite'>Noite</option>  
                                         </select>
                                     </div>
                                     <div class="col-sm-12 text-right mt-3">
@@ -228,9 +228,14 @@ class LoopUnidadesTabs extends LoopUnidades{
                                 'posts_per_page' => 16,
                                 'paged' => $paged,
                                 'meta_query' => array(
+                                    'relation' => 'OR',
                                     array(
                                         'key' => 'localizacao',
                                         'value' => $id
+                                    ),
+                                    array(
+                                        'key' => 'localizacao',
+                                        'value' => 31675
                                     )
                                 )
                             );
@@ -252,7 +257,8 @@ class LoopUnidadesTabs extends LoopUnidades{
                                                     <?php 
                                                         $imgSelect = get_field('capa_do_evento', $eventoID);
                                                         $tipo = get_field('tipo_de_evento_selecione_o_evento', $eventoID);
-                                                        
+                                                        $online = get_field('tipo_de_evento_online', $eventoID);
+
                                                         $featured_img_url = wp_get_attachment_image_src($imgSelect, 'thumb-eventos');
                                                         if($featured_img_url){
                                                             $imgEvento = $featured_img_url[0];
@@ -264,6 +270,19 @@ class LoopUnidadesTabs extends LoopUnidades{
                                                         }
                                                     ?>
                                                     <a href="#"><img src="<?php echo $imgEvento; ?>" class="img-fluid d-block" alt="<?php echo $alt; ?>"></a>
+                                                    <?php if($tipo && $tipo != '') : 
+                                                        echo '<span class="flag-pdf-full">';
+                                                            echo get_the_title($tipo);
+                                                        echo '</span>';
+                                                    endif; ?>
+                                                    <?php if($online && $online != '') : 
+                                                        if($tipo && $tipo != ''){
+                                                            $customClass = 'mt-tags';
+                                                        }
+                                                        echo '<span class="flag-online flag-pdf-full ' . $customClass . '">';
+                                                            echo "Evento Online";
+                                                        echo '</span>';
+                                                    endif; ?>
                                                 </div>
                                                 <div class="card-eventos-content p-2">
                                                 <div class="evento-categ border-bottom pb-1">
@@ -440,9 +459,13 @@ class LoopUnidadesTabs extends LoopUnidades{
                                                         <i class="fa fa-clock-o" aria-hidden="true"><span>icone horario</span></i> <?php echo $hora; ?>
                                                     </p>
                                                     <?php
-                                                        $local = get_field('localizacao', $eventoID);                                                
+                                                        $local = get_field('localizacao', $eventoID);                                                        
+                                                        if($local == '31675' || $local == '31244'):
                                                     ?>
-                                                    <p class="mb-0 mt-1 evento-unidade"><a href="<?php echo get_the_permalink($local); ?>"><i class="fa fa-map-marker" aria-hidden="true"><span>icone unidade</span></i> <?php echo get_the_title($local); ?></a></p>
+                                                        <p class="mb-0 mt-1 evento-unidade no-link"><i class="fa fa-map-marker" aria-hidden="true"><span>icone unidade</span></i> <?php echo get_the_title($local); ?></p>
+                                                    <?php else: ?>
+                                                        <p class="mb-0 mt-1 evento-unidade"><a href="<?php echo get_the_permalink($local); ?>"><i class="fa fa-map-marker" aria-hidden="true"><span>icone unidade</span></i> <?php echo get_the_title($local); ?></a></p>
+                                                    <?php endif; ?>
                                                 </div>
                                             </div>
                                     </div>

--- a/wp-content/themes/tema-ceus/search.php
+++ b/wp-content/themes/tema-ceus/search.php
@@ -94,6 +94,7 @@
 									$argsUnidades = array(
 										'post_type' => 'unidade',
 										'posts_per_page' => -1,
+										'post__not_in' => array(31244, 31675),
 									);
 
 									$todasUnidades = new \WP_Query( $argsUnidades );
@@ -144,10 +145,10 @@
                         </div>
 
                         <div class="col-sm-3 mt-3 px-1">
-                            <select name="periodos[]" multiple="multiple" class="ms-list-8" style="">                        
-                                <?php foreach ($periodos as $periodo): ?>
-                                    <option value="<?php echo $periodo->term_id; ?>"><?php echo $periodo->name; ?></option>
-                                <?php endforeach; ?>                        
+							<select name="periodos[]" multiple="multiple" class="ms-list-8" style="">                        
+								<option value='manha'>Manhã</option>
+                                <option value='tarde'>Tarde</option>
+                                <option value='noite'>Noite</option>                          
                             </select>
                         </div>
                         <div class="col-sm-12 text-right mt-3">
@@ -231,18 +232,123 @@
 
 				$args['meta_query'] = array(
 					'relation'	=> 'OR',
+					array(
+						'key'	 	=> 'localizacao',
+						'value'	  	=> 31675
+					),
 					$unidadesBusca						
 				);
 			}
 
 			if( isset($_GET['periodos']) && $_GET['periodos'] != ''){
 				$periodos = $_GET['periodos'];
-				
-				$args['tax_query'][] = array (
-					'taxonomy' => 'periodo_categories',
-					'field'    => 'term_id',
-					'terms'    => $periodos,
+
+				$args['meta_query'] = array(
+					'relation'	=> 'OR',
 				);
+
+				if(in_array('manha', $periodos)){
+					$args['meta_query'][] = array(
+						'relation' => 'AND',
+						array(
+							'relation' => 'OR',
+							array(
+								'key'	 	=> 'horario_hora',
+								'value' => '00:00:00',
+								'compare' => '>='
+							),
+							array(
+								'key'	 	=> 'horario_hora_periodo_0_periodo_hora_inicio',
+								'value' => '00:00:00',
+								'compare' => '>='
+							),
+						),
+	
+						array(
+							'relation' => 'OR',
+							array(
+								'key'	 	=> 'horario_hora',
+								'value' => '11:59:59',
+								'compare' => '<='
+							),
+							array(
+								'key'	 	=> 'horario_hora_periodo_0_periodo_hora_inicio',
+								'value' => '11:59:59',
+								'compare' => '<='
+							),	
+						),
+					);
+				}
+
+				if(in_array('tarde', $periodos)){
+					$args['meta_query'][] = array(
+						'relation' => 'AND',
+						array(
+							'relation' => 'OR',
+							array(
+								'key'	 	=> 'horario_hora',
+								'value' => '12:00:00',
+								'compare' => '>='
+							),
+							array(
+								'key'	 	=> 'horario_hora_periodo_0_periodo_hora_inicio',
+								'value' => '12:00:00',
+								'compare' => '>='
+							),
+						),
+	
+						array(
+							'relation' => 'OR',
+							array(
+								'key'	 	=> 'horario_hora',
+								'value' => '18:59:59',
+								'compare' => '<='
+							),
+							array(
+								'key'	 	=> 'horario_hora_periodo_0_periodo_hora_inicio',
+								'value' => '18:59:59',
+								'compare' => '<='
+							),	
+						),
+					);
+				}
+
+				if(in_array('noite', $periodos)){
+					$args['meta_query'][] = array(
+						'relation' => 'AND',
+						array(
+							'relation' => 'OR',
+							array(
+								'key'	 	=> 'horario_hora',
+								'value' => '19:00:00',
+								'compare' => '>='
+							),
+							array(
+								'key'	 	=> 'horario_hora_periodo_0_periodo_hora_inicio',
+								'value' => '19:00:00',
+								'compare' => '>='
+							),
+						),
+	
+						array(
+							'relation' => 'OR',
+							array(
+								'key'	 	=> 'horario_hora',
+								'value' => '23:59:59',
+								'compare' => '<='
+							),
+							array(
+								'key'	 	=> 'horario_hora_periodo_0_periodo_hora_inicio',
+								'value' => '23:59:59',
+								'compare' => '<='
+							),	
+						),
+					);
+				}
+
+				
+								
+								
 			}
 
 			if( isset($_GET['tipoData']) && $_GET['tipoData'] != ''){
@@ -366,12 +472,13 @@
 						$query->the_post();
 					?>
 						<div class="col-sm-3">
-							<div class="card-eventos">
+							<div class="card-eventos mb-4">
 								<div class="card-eventos-img">
 									<?php 
 										$imgSelect = get_field('capa_do_evento', $eventoInterno->ID);
 										$tipo = get_field('tipo_de_evento_selecione_o_evento', $eventoInterno->ID);
-										
+										$online = get_field('tipo_de_evento_online', $eventoInterno->ID);
+
 										$featured_img_url = wp_get_attachment_image_src($imgSelect, 'thumb-eventos');
 										if($featured_img_url){
 											$imgEvento = $featured_img_url[0];
@@ -383,6 +490,19 @@
 										}
 									?>
 									<a href="<?php get_the_permalink($eventoInterno->ID);?>"><img src="<?php echo $imgEvento; ?>" class="img-fluid d-block" alt="<?php echo $alt; ?>"></a>
+									<?php if($tipo && $tipo != '') : 
+										echo '<span class="flag-pdf-full">';
+											echo get_the_title($tipo);
+										echo '</span>';
+									endif; ?>
+									<?php if($online && $online != '') : 
+										if($tipo && $tipo != ''){
+											$customClass = 'mt-tags';
+										}
+										echo '<span class="flag-pdf-full ' . $customClass . '">';
+											echo "Online";
+										echo '</span>';
+									endif; ?>
 								</div>
 								<div class="card-eventos-content p-2">
 									<div class="evento-categ border-bottom pb-1">
@@ -558,9 +678,13 @@
 											<i class="fa fa-clock-o" aria-hidden="true"><span>icone horario</span></i> <?php echo $hora; ?>
 										</p>
 										<?php
-											$local = get_field('localizacao', get_the_ID());                                                
+											$local = get_field('localizacao', get_the_ID());                                                        
+											if($local == '31675' || $local == '31244'):
 										?>
-										<p class="mb-0 mt-1 evento-unidade"><a href="<?php echo get_the_permalink($local); ?>"><i class="fa fa-map-marker" aria-hidden="true"><span>icone unidade</span></i> <?php echo get_the_title($local); ?></a></p>
+											<p class="mb-0 mt-1 evento-unidade no-link"><i class="fa fa-map-marker" aria-hidden="true"><span>icone unidade</span></i> <?php echo get_the_title($local); ?></p>
+										<?php else: ?>
+											<p class="mb-0 mt-1 evento-unidade"><a href="<?php echo get_the_permalink($local); ?>"><i class="fa fa-map-marker" aria-hidden="true"><span>icone unidade</span></i> <?php echo get_the_title($local); ?></a></p>
+										<?php endif; ?>
 								</div>
 							</div>
                     	</div>

--- a/wp-content/themes/tema-ceus/style.css
+++ b/wp-content/themes/tema-ceus/style.css
@@ -1190,8 +1190,13 @@ select#tipoData {
     color: #42474A;
 }
 
-.evento-unidade a {
+.evento-unidade a,
+.evento-unidade.no-link {
     color: #0048A9;
+}
+
+.evento-unidade span {
+    display: none;
 }
 
 .atividades-found p span {
@@ -1327,6 +1332,14 @@ select#tipoData {
     font-size: 15px;
     font-weight: bold;
     margin-right: 15px;
+}
+
+.flag-pdf-full.mt-tags {
+    margin-top: 45px;
+}
+
+.flag-online.flag-pdf-full {
+    background: #0048A9;
 }
 
 .bg-tipo {


### PR DESCRIPTION
- Inclusão da opção "Toda a rede" para eventos que são oferecidos por COCEU;
- Inclusão da opção "Online" para eventos que são online;
- Alteração na página de cada CEU para trazer além dos eventos do próprio CEU também trazer os eventos que são de toda a rede.
- Alteração na página individual do evento, slides e listagem de eventos para remover o link que leva para a unidade pertencente nos casos dos eventos que são para toda a rede;
- Alteração no _Breadcrumb_ para mostrar a unidade no lugar da categoria.