### PR TITLE
Adicionando link permanente para colaboradores ao enviar para revisao

### DIFF
--- a/wp-admin/edit-form-advanced.php
+++ b/wp-admin/edit-form-advanced.php
@@ -513,7 +513,7 @@ do_action( 'edit_form_top', $post );
 			}
 		}
 
-		if ( $post_type_object->public && ! ( 'pending' == get_post_status( $post ) && ! current_user_can( $post_type_object->cap->publish_posts ) ) ) {
+		if ( $post_type_object->public ) {
 			$has_sample_permalink = $sample_permalink_html && 'auto-draft' != $post->post_status;
 			?>
 	<div id="edit-slug-box" class="hide-if-no-js">

--- a/wp-admin/includes/meta-boxes.php
+++ b/wp-admin/includes/meta-boxes.php
@@ -1507,9 +1507,9 @@ function register_and_do_post_meta_boxes( $post ) {
 		}
 	}
 
-	if ( ! ( 'pending' == get_post_status( $post ) && ! current_user_can( $post_type_object->cap->publish_posts ) ) ) {
+	//if ( ! ( 'pending' == get_post_status( $post ) && ! current_user_can( $post_type_object->cap->publish_posts ) ) ) {
 		add_meta_box( 'slugdiv', __( 'Slug' ), 'post_slug_meta_box', null, 'normal', 'core', array( '__back_compat_meta_box' => true ) );
-	}
+	//}
 
 	if ( post_type_supports( $post_type, 'author' ) && current_user_can( $post_type_object->cap->edit_others_posts ) ) {
 		add_meta_box( 'authordiv', __( 'Author' ), 'post_author_meta_box', null, 'normal', 'core', array( '__back_compat_meta_box' => true ) );

--- a/wp-includes/post.php
+++ b/wp-includes/post.php
@@ -3505,12 +3505,13 @@ function wp_insert_post( $postarr, $wp_error = false ) {
 	 * For new posts check the primitive capability, for updates check the meta capability.
 	 */
 	$post_type_object = get_post_type_object( $post_type );
-
+	/*
 	if ( ! $update && 'pending' === $post_status && ! current_user_can( $post_type_object->cap->publish_posts ) ) {
 		$post_name = '';
 	} elseif ( $update && 'pending' === $post_status && ! current_user_can( 'publish_post', $post_ID ) ) {
 		$post_name = '';
 	}
+	*/
 
 	/*
 	 * Create a valid post name. Drafts and pending posts are allowed to have


### PR DESCRIPTION
- Ajuste de bug no Core do WordPress para que os links permanentes não sejam alterados após a publicação ser enviada para revisão por usuários do tipo Colaborador.