### PR TITLE
Definir imagem de destaque padrão nas noticias

### DIFF
--- a/wp-content/themes/sme-portal-institucional/classes/Cpt/CptPosts.php
+++ b/wp-content/themes/sme-portal-institucional/classes/Cpt/CptPosts.php
@@ -21,7 +21,7 @@ class CptPosts extends Cpt
 				'categories' => 'Categories',
 				'tags' => 'Tags',
 				'comments' => '<span class="vers"><div title="Comments" class="comment-grey-bubble"></div></span>',
-				'featured_thumb' => 'Thumbnail',				
+				'featured_thumb' => 'Thumbnail',
 				'date' => 'Date',
 
 			);
@@ -37,10 +37,10 @@ class CptPosts extends Cpt
 		switch ( $column ) {
 			case 'featured_thumb':
 				echo '<a href="' . get_edit_post_link() . '">';
-				echo the_post_thumbnail( 'admin-list-thumb' );
+				$thumb = get_thumb($post_id);
+				echo "<img src='" . $thumb[0] . "' style='max-width: 100%;'>";
 				echo '</a>';
 				break;
 		}
 	}
-
 }

--- a/wp-content/themes/sme-portal-institucional/functions.php
+++ b/wp-content/themes/sme-portal-institucional/functions.php
@@ -1217,3 +1217,27 @@ function my_acf_fields_post_object_query( $args, $field, $post_id ) {
 
     return $args;
 }
+
+// Definir imagem destacada padrao
+
+function fpw_post_info( $id, $post ) {
+
+	$firstImage = get_first_image($post->ID);
+
+    if( has_post_thumbnail( $post->ID ) ){
+
+		$idThumb = get_post_thumbnail_id($post->ID);
+		set_post_thumbnail( $post->ID, $idThumb );
+
+	} elseif($firstImage){
+
+		set_post_thumbnail( $post->ID, $firstImage );
+
+	} else {
+
+		delete_post_meta( $post->ID, '_thumbnail_id' );
+		set_post_thumbnail( $post->ID, 23755 );
+		
+	}
+}
+add_action( 'publish_post', 'fpw_post_info', 10, 2 );


### PR DESCRIPTION
- Definir para notícias que não possuem imagem destacada uma imagem padrão;
- Exibir as imagens destacadas na listagem de noticias