### PR TITLE
Validacao para links de componentes

### DIFF
--- a/wp-content/themes/sme-portal-institucional/classes/ModelosDePaginas/PaginaImagemVideo/PaginaImagemVideo.php
+++ b/wp-content/themes/sme-portal-institucional/classes/ModelosDePaginas/PaginaImagemVideo/PaginaImagemVideo.php
@@ -59,7 +59,7 @@ class PaginaImagemVideo extends Util
 		if (have_posts()) : while (have_posts()) : the_post();
 			?>
 			<section class="row">
-				<article class="col-lg-9 col-xs-12">
+				<article class="col-lg-9 col-xs-12" id="conteudo">
 					<h1 class="mb-5" id="<?= $this->page_slug ?>"><?php the_title(); ?></h1>
 					<?php echo $this->getSubtitulo($this->page_id)?>
 					<?= $this->getImagemOuVideo(); ?>

--- a/wp-content/themes/sme-portal-institucional/footer.php
+++ b/wp-content/themes/sme-portal-institucional/footer.php
@@ -115,9 +115,11 @@
 			var href = $(this).attr('href');
 			var valor = $(this).html();
 
-			if(!href.includes("https://hom-educacao.sme.prefeitura.sp.gov.br")){
-				$(this).html(valor + ' <span class="screen-reader-text">(Link para um novo sítio)</span><span aria-hidden="true" class="dashicons dashicons-external"></span>');
-			}
+			if( !href.startsWith('#') && !valor.includes('<button') && !href.includes('tel:') && !href.includes('mailto:')){
+				if(!href.includes("https://educacao.sme.prefeitura.sp.gov.br")){
+					$(this).html(valor + ' <span class="screen-reader-text">(Link para um novo sítio)</span><span aria-hidden="true" class="dashicons dashicons-external"></span>');
+				}
+			}			
 			
 		});
 	} );


### PR DESCRIPTION
Alteração para regra de validação de links excluindo itens de ação como seta do slide, botões de abas e acordeons e links de telefone e email.