### PR TITLE
Nao disparar email em caso de preview das noticias

### DIFF
--- a/_git_plugins/email-admin-ceu/email-admin-ceu.php
+++ b/_git_plugins/email-admin-ceu/email-admin-ceu.php
@@ -10,7 +10,8 @@ Author URI: https://www.amcom.com.br
 */
 
 function post_unpublished( $new_status, $old_status, $post ) {
-    if ( ($old_status == 'publish' || $old_status =='new')  &&  $new_status == 'pending' ) {
+    
+    if ( ($old_status == 'publish' &&  $new_status == 'pending') || ($old_status == 'pending' &&  $new_status == 'pending') || ($old_status == 'draft' &&  $new_status == 'pending') ) {
         
         if ( ! $post_type = get_post_type_object( $post->post_type ) )
         return;
@@ -99,6 +100,7 @@ function post_unpublished( $new_status, $old_status, $post ) {
         }
         
         // evia o email
+        //$emailto2 = 'felipe.almeida@amcom.com.br';
         wp_mail( $emailto, $subject, $message );
     }
 }

--- a/wp-content/themes/tema-ceus/functions.php
+++ b/wp-content/themes/tema-ceus/functions.php
@@ -1730,8 +1730,7 @@ function custom_wp_new_user_notification_email( $wp_new_user_notification_email,
 	return $wp_new_user_notification_email;
 }
 
-// Enviar eventos para revisao em caso de Colaborador
-add_filter('wp_insert_post_data', 'change_post_status', '99');
+add_filter('wp_insert_post_data', 'change_post_status', '100');
 
 function change_post_status($data)
 {
@@ -1739,7 +1738,20 @@ function change_post_status($data)
     {
         if(defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) return;
         //then set the fields you want to update
-        $data['post_status'] = 'pending';     
+		if($data['post_status'] == 'publish'){
+			$data['post_status'] = 'pending';
+		}		
     }
     return $data;
 }
+
+
+// Permitir que colaboradores possam ver o preview dos posts
+function jv_change_post( $posts ) {
+    if(is_preview() && !empty($posts)){        
+        $posts[0]->post_status = 'publish';
+    }
+
+    return $posts;
+}
+add_filter( 'posts_results', 'jv_change_post', 10, 2 );


### PR DESCRIPTION
- Não disparar emails para administradores em caso de utilização da funcionalidade "Visualizar" dos eventos
- Permitir que colabores utilizem a função "Visualizar" nos eventos 