### PR TITLE
Feature/53447 renomear menu rodape admin

### DIFF
--- a/wp-content/themes/sme-portal-institucional/functions.php
+++ b/wp-content/themes/sme-portal-institucional/functions.php
@@ -654,13 +654,13 @@ if( function_exists('acf_add_options_page') ) {
     ));
 
     acf_add_options_sub_page(array(
-        'page_title' 	=> 'Informações Rodapé',
-        'menu_title'	=> 'Rodapé',
+        'page_title' 	=> 'Informações Rodapé e Topo',
+        'menu_title'	=> 'Rodapé e Topo',
         'parent_slug'	=> 'conf-geral',
         'capability'	=> 'publish_pages',
 		'post_id' => 'conf-rodape',
 		'update_button' => __('Atualizar', 'acf'),
-		'updated_message' => __("Informações do Rodapé atualizado com sucesso", 'acf'),
+		'updated_message' => __("Informações do Rodapé e Topo atualizados com sucesso", 'acf'),
     ));
 
 	acf_add_options_sub_page(array(

--- a/wp-content/themes/tema-conselhos/functions.php
+++ b/wp-content/themes/tema-conselhos/functions.php
@@ -690,13 +690,13 @@ if( function_exists('acf_add_options_page') ) {
 	));
 	
 	acf_add_options_sub_page(array(
-        'page_title' 	=> 'Informações Rodapé',
-        'menu_title'	=> 'Rodapé',
+        'page_title' 	=> 'Informações Rodapé e Topo',
+        'menu_title'	=> 'Rodapé e Topo',
         'parent_slug'	=> 'conf-geral',
         'capability'	=> 'publish_pages',
 		'post_id' => 'conf-rodape',
 		'update_button' => __('Atualizar', 'acf'),
-		'updated_message' => __("Informações do Rodapé atualizado com sucesso", 'acf'),
+		'updated_message' => __("Informações do Rodapé e Topo atualizados com sucesso", 'acf'),
     ));
 
 }

--- a/wp-content/themes/tema-dres/functions.php
+++ b/wp-content/themes/tema-dres/functions.php
@@ -685,13 +685,13 @@ if( function_exists('acf_add_options_page') ) {
 	));
 	
 	acf_add_options_sub_page(array(
-        'page_title' 	=> 'Informações Rodapé',
-        'menu_title'	=> 'Rodapé',
+        'page_title' 	=> 'Informações Rodapé e Topo',
+        'menu_title'	=> 'Rodapé e Topo',
         'parent_slug'	=> 'conf-geral',
         'capability'	=> 'publish_pages',
 		'post_id' => 'conf-rodape',
 		'update_button' => __('Atualizar', 'acf'),
-		'updated_message' => __("Informações do Rodapé atualizado com sucesso", 'acf'),
+		'updated_message' => __("Informações do Rodapé e Topo atualizados com sucesso", 'acf'),
     ));
 
 }


### PR DESCRIPTION
- Alteração do Item de menu "Rodapé" para "Rodapé e Topo" no admin do Portal, Conselhos e DREs