### PR TITLE
Abrir conteudo da sanfona no topo da pagina

### DIFF
--- a/wp-content/themes/sme-portal-institucional/classes/ModelosDePaginas/Layout/construtor.php
+++ b/wp-content/themes/sme-portal-institucional/classes/ModelosDePaginas/Layout/construtor.php
@@ -32,6 +32,10 @@ class Construtor extends Util
 				jQuery(".card-header").on('click', function(){
 					jQuery(".card-header").removeClass('bg-sanfona-active');
 					jQuery(this).addClass('bg-sanfona-active');
+					
+					if(jQuery(this).find('.card-link').hasClass('collapsed')){
+						jQuery(window).scrollTop( jQuery(this).offset().top );						
+					}
 				});
 			});
 		</script>


### PR DESCRIPTION
Ao abrir a o elemento "Sanfona" do Construtor de Página a rolagem da página seja levada para o conteúdo da Sanfona abrindo no topo do navegador.