### PR TITLE
Incluir paginas em rascunho e pendente no seletor de subpaginas

### DIFF
--- a/wp-content/themes/sme-portal-institucional/functions.php
+++ b/wp-content/themes/sme-portal-institucional/functions.php
@@ -1795,3 +1795,13 @@ function wpdocs_my_custom_submenu_page_callback() {
 	<?php
     echo '</div>';
 }
+
+// Paginas em rascunho e pendendentes no seletor de subpaginas
+add_filter( 'page_attributes_dropdown_pages_args', 'so_3538267_enable_drafts_parents' );
+add_filter( 'quick_edit_dropdown_pages_args', 'so_3538267_enable_drafts_parents' );
+
+function so_3538267_enable_drafts_parents( $args )
+{
+    $args['post_status'] = 'draft,publish,pending';
+    return $args;
+}


### PR DESCRIPTION
Incluir no seletor de "Página Ascendente" as páginas que estiverem com o status de Rascunho e Revisão Pendente.