### PR TITLE
Expandir imagens de tamanho padrao

### DIFF
--- a/wp-content/themes/sme-portal-institucional/style.css
+++ b/wp-content/themes/sme-portal-institucional/style.css
@@ -1098,8 +1098,8 @@ footer .redes-footer {
     color: #42474A !important;
 }
 
-.content-article img,
-.editor-content img {
+.content-article img.size-default-image,
+.editor-content img.size-default-image {
     width: 100%;
 }
 


### PR DESCRIPTION
Expandir imagens de tamanho padrão (seleção de tamanho no admin do portal) para a largura total do conteúdo