### PR TITLE
Escolher noticias em destaque

### DIFF
--- a/wp-content/themes/sme-portal-institucional/construtor/construtor-noticias_destaque_dre.php
+++ b/wp-content/themes/sme-portal-institucional/construtor/construtor-noticias_destaque_dre.php
@@ -1,194 +1,93 @@
-<?php
-
-namespace Classes\Cpt;
-
-
-class CptAgendaDreSmi extends Cpt
-{
-	public function __construct(){
-		$this->cptSlug = self::getCptSlugExtend();
-		$this->name = self::getNameExtend();
-		$this->todosOsItens = self::getTodosOsItensExtend();
-		$this->dashborarIcon = self::getDashborarIconExtendExtend();
-
-		add_action('init', array($this, 'register'));
-
-		//Alterando e Exibindo as colunas no Dashboard que vem por padrão na classe CPT
-		add_filter('manage_posts_columns', array($this, 'exibe_cols'), 10, 2);
-		add_action('manage_' . $this->cptSlug . '_posts_custom_column', array($this, 'cols_content'));
-		add_filter('manage_edit-' . $this->cptSlug . '_sortable_columns', array($this, 'cols_sort'));
-		add_filter('request', array($this, 'orderby'));
-	}
-
-	//Exibindo as colunas no Dashboard
-	public function exibe_cols($cols, $post_type)
-	{
-
-		if ($post_type == $this->cptSlug) {
-			unset($cols['tags'],$cols['categories'],$cols['comments'], $cols['categoria'], $cols['featured_thumb'], $cols['wpseo-links']);
-			$cols['author'] = 'Autor';
-			$cols['data_evento'] = 'Data do Evento';
-			$cols['qtd_evento'] = 'Quantidade de eventos';
-			//$cols['imagem'] = 'Imagem';
-		}
-		return $cols;
-	}
-
-	//Exibindo as informações correspondentes de cada coluna
-	public function cols_content($col)
-	{
-		global $post;
-		switch ($col) {
-			case 'data_evento':
-				$data_do_evento = get_field('data_do_evento', $post->ID);
-				//if( !isset($_GET['orderby']) || $_GET['orderby'] == 'data_evento' ){
-					//echo date("d/m/Y", strtotime($data_do_evento));
-				//} else {
-					echo $data_do_evento;
-				//}				
-				
-				break;
-
-			case 'qtd_evento':
-				$qtd_evento = get_field('eventos_do_dia', $post->ID);
-				//print_r($qtd_evento);
-				$qtd = count($qtd_evento);
-				if( !isset($_GET['orderby']) || $_GET['orderby'] == 'data_evento'){
-					$qtd = count($qtd_evento);
-				}
-				if($qtd == 1){
-					echo $qtd . ' evento';
-				} elseif($qtd > 1) {
-					echo $qtd . ' eventos';
-				} else {
-					echo ' - ';
-				}
-				
-				break;
+<section class="container mt-5 noticias">
+    <section class="row">
+                   
+        <?php
+            $selecao = get_sub_field('tipo_de_selecao');
+            $categorias = get_sub_field('categoria');
+            $noticias = get_sub_field('noticias');
+            $maisNoticias = get_sub_field('link_mais_noticias');
 			
-		}
-	}
+            $args = array(
+                'post_type' => 'post',                    
+                'posts_per_page' => 3,
+            );
 
-	// Permitindo a ordenação das colunas exibidas no Dashboard
-	function cols_sort($cols)
-	{
-		$cols['data_evento'] = 'data_evento';
-		$cols['hora_evento'] = 'Hora do Evento';
-		$cols['local_evento'] = 'Local do Evento';
-		return $cols;
-	}
+            if($selecao){
+                $args['post__in'] = $noticias;
+            } else {
+                $args['cat'] = $categorias;
+            }
 
-	function orderby($vars)
-	{
-		if (is_admin()) {
-			if (isset($vars['orderby']) && $vars['orderby'] == 'data_evento') {
-				$vars['orderby'] = 'meta_value_num date';
-				$vars['meta_key'] = 'data_do_evento';
-			}
+            $query = new WP_Query( $args );
+            $count = 0;
+            if ($query->have_posts()) : 
 
-			if (isset($vars['orderby']) && $vars['orderby'] == 'hora_evento') {
-				$vars['orderby'] = 'menu_order';
-			}
+                while ($query->have_posts()) : $query->the_post();
+                    if($count == 0):
+                ?>
+                    <section class="col-lg-6 col-xs-12 mb-xs-4 rounded">
+                        <article class="card h-100 rounded border-0">
+                            <?php
+                                // Busca a imagem destaca / primeira imagem / imagem padrao -- functions.php
+                                $thumbs = get_thumb($noticiasDest[0], 'default-image');
+                            ?>
+                            <img src="<?php echo $thumbs[0]; ?>" alt="<?php echo $thumbs[1]; ?>" class="rounded img-fluid">
+                            <article class="card-img-overlay bg-home-desc h-auto rounded-bottom container-img-noticias-destaques-primaria">
+                                <h3 class="fonte-catorze font-weight-bold">
+                                    <a class="text-white" href="<?= get_the_permalink(); ?>">
+                                        <?= get_the_title(); ?>
+                                    </a>
+                                </h3>
+                                <section class="card-text text-white fonte-doze"><p class="mb-3 "><?= get_field('insira_o_subtitulo'); ?></p></section>
+                            </article>
+                        </article>
+                    </section>
+                <?php else: ?>
 
-			if (isset($vars['orderby']) && $vars['orderby'] == 'local_evento') {
-				$vars['orderby'] = 'menu_order';
-			}
-		}
-		return $vars;
-	}
-
-
-	/**
-	 * Alterando as configurações que vem por padrão na classe CPT (Adicionando suporte a thumbnail)
-	 */
-	public function register()
-	{
-		$labels = array(
-			'name' => _x($this->name, 'post type general name'),
-			'singular_name' => _x($this->name, 'post type singular name'),
-			'all_items' => _x( $this->todosOsItens, 'Admin Menu todos os itens'),
-			'add_new' => _x('Adicionar evento ', 'Novo item'),
-			'add_new_item' => __('Novo Item'),
-			'edit_item' => __('Editar Item'),
-			'new_item' => __('Novo Item'),
-			'view_item' => __('Ver Item'),
-			'search_items' => __('Procurar Itens'),
-			'not_found' => __('Nenhum registro encontrado'),
-			'not_found_in_trash' => __('Nenhum registro encontrado na lixeira'),
-			'parent_item_colon' => '',
-			'menu_name' => $this->name
-		);
-
-		$args = array(
-			'labels' => $labels,
-			'public' => true,
-			'public_queryable' => true,
-			'show_ui' => true,
-			'show_in_menu' => true,
-			'query_var' => true,
-			'rewrite' => array( 'slug' => $this->cptSlug, 'with_front' => false ),
-			'capability_type' => array('concurso','concursos'),
-			'map_meta_cap'    => true,
-			'capabilities' => array(
-				'edit_post' => 'edit_concurso',
-				'edit_posts' => 'edit_concursos',
-				'edit_published_posts ' => 'edit_published_concursos',
-				'edit_others_posts' => 'edit_others_concursos',
-				'read_post' => 'read_concurso',
-				'read_private_posts' => 'read_private_concursos',
-				'delete_post' => 'delete_concurso',
-				'delete_published_posts' => 'delete_published_concursos',
-				'publish_posts' => 'publish_concursos'
-			),
-			'has_archive' => true,
-			'hierarchical' => false,
-			'menu_position' => 10,
-			'menu_icon'   => $this->dashborarIcon,
-			'exclude_from_search' => true,
-			'show_in_rest' => true,
-			'rest_controller_class' => 'WP_REST_Posts_Controller',
-			'supports' => array('revisions'),
-		);
-
-		register_post_type($this->cptSlug, $args);
-
-		remove_post_type_support( $this->cptSlug, 'editor' );
-		//remove_post_type_support( $this->cptSlug, 'title' );
-
-		flush_rewrite_rules();
-
-		// Categorias Compromissos
-		register_taxonomy(
-			'compromisso',
-			$this->cptSlug,
-			array(
-				"label" => 'Compromissos',
-				"singular_label" => 'Compromisso',
-				"hierarchical" => true,
-				'show_ui' => true,
-				'meta_box_cb' => false,
-				'query_var' => true,
-				'show_in_rest' => true,
-				'show_in_quick_edit' => false,
-				'rest_controller_class' => 'WP_REST_Terms_Controller',
-			)
-		);
-
-		// Categorias Enderecos
-		register_taxonomy(
-			'endereco',
-			$this->cptSlug,
-			array(
-				"label" => 'Endereços',
-				"singular_label" => 'Endereço',
-				"hierarchical" => true,
-				'show_ui' => true,
-				'meta_box_cb' => false,
-				'query_var' => true,
-				'show_in_rest' => true,
-				'show_in_quick_edit' => false,
-				'rest_controller_class' => 'WP_REST_Terms_Controller',
-			)
-		);
-	}
-}
+                    <?php if($count == 1): ?>
+                        <section class="col-lg-6 col-xs-12">
+                    <?php endif; ?>
+                    
+                    <article class="row mb-4 b-home border-bottom">
+                        <div class="col-12 col-md-5 mb-1">                            
+                            <?php
+                                // Busca a imagem destaca / primeira imagem / imagem padrao -- functions.php
+                                $thumbs = get_thumb($noticiasDest[0], 'default-image');
+                            ?>
+                            <img src="<?php echo $thumbs[0]; ?>" alt="<?php echo $thumbs[1]; ?>" class="img-fluid rounded float-left mr-4 img-noticias-destaques-secundarias desc2-img-home">
+                        </div>
+                        <div class="col-12 col-md-7">
+                            <h3 class="fonte-catorze font-weight-bold">
+                                <a class="text-dark" href="<?= get_the_permalink(); ?>"><?= get_the_title(); ?></a>
+                            </h3>
+                            <section class="fonte-doze"><span class="mb-3 "><p class="mb-3 "><?= get_field('insira_o_subtitulo'); ?></p></span></section>
+                        </div>
+                    </article>
+                <?php
+                    endif;
+                    $count++;
+                endwhile;
+                    if($maisNoticias):
+                ?>
+                     <section class="row">
+                        <article class="col-lg-12 col-xs-12 container-btn-mais-noticias">
+                            <form>
+                                <fieldset>
+                                    <legend>Ir para mais notícias</legend>
+                                    <a href="<?= $maisNoticias; ?>" class="btn btn-primary btn-sm btn-block bg-azul-escuro font-weight-bold text-white">Mais notícias</a>
+                                </fieldset>
+                            </form>
+                        </article>
+                    </section>   
+                <?php
+                    endif; 
+                    echo '</section>';
+                    
+            else:
+                echo '<p class="agenda agenda-new"><strong>Não existem eventos cadastrados nesta data</strong></p>';
+            endif;
+            wp_reset_postdata();
+        ?>
+		
+    </section>
+</section>

--- a/wp-content/themes/sme-portal-institucional/functions.php
+++ b/wp-content/themes/sme-portal-institucional/functions.php
@@ -2800,3 +2800,33 @@ function nsf_exclude_cats( $exclusions ) {
     }
     return $exclusions;
 }
+
+add_filter('acf/fields/relationship/query/key=field_63640d0347c62', 'filter_by_user_group', 10, 3);
+function filter_by_user_group( $args, $field, $post_id ) {
+
+	$user = wp_get_current_user();
+
+	if ( in_array( 'dre', (array) $user->roles ) ) {
+		
+		$grupos = get_user_meta($user->ID,'grupo',true);
+		$categorias = array();
+		
+		if($grupos && $grupos !=''){
+			//if($grupos && $grupos != ''){
+				foreach($grupos as $grupo){
+					$categorias[] = get_post_meta($grupo, 'noticias', true);
+				}
+			//}
+	
+			$categorias = array_flatten($categorias);
+			$categorias = array_unique($categorias);
+						
+			$result = array_unique($categorias);
+			$result = array_filter($result);
+
+		}
+		$args['cat'] = $result;
+	}
+
+    return $args;
+}


### PR DESCRIPTION
Alteração no elemento do Construtor de Páginas "Noticias de destaque - DRE" incluindo a possibilidade de selecionar as noticias por categoria ou por seleção manual e incluindo filtro de notícias para usuários do tipo DRE baseado nas categorias liberadas para o seu grupo.