### PR TITLE
Gerenciamento de usuarios por grupo para editores

### DIFF
--- a/wp-content/themes/tema-ceus/css/admin.css
+++ b/wp-content/themes/tema-ceus/css/admin.css
@@ -24,3 +24,7 @@
 .tooltip:hover .tooltiptext {
     visibility: visible;
 }
+
+.user-language-wrap{
+    display: none;
+}


### PR DESCRIPTION
- Ocultar campos no cadastro de usuários
- Limitar o seletor de grupos para o cadastro de novos usuários
- Ocultar o contador de usuários por tipo