### PR TITLE
Manter formatacao de texto no auto salvamento para campos personalizados

### DIFF
--- a/wp-content/themes/tema-ceus/functions.php
+++ b/wp-content/themes/tema-ceus/functions.php
@@ -1831,7 +1831,7 @@ function hcf_save( $post_id ) {
 		update_post_meta(
 			$post_id,
 			'descricao',
-			sanitize_text_field( $_POST['acf']["field_6005f383003ea"] )
+			$_POST['acf']["field_6005f383003ea"]
 		);
 	}
 	


### PR DESCRIPTION
Permitir salvamento de formatação de texto na funcionalidade de auto salvamento do WordPress para o campo personalizado "Descrição" utilizado no cadastro das unidades dos CEUs