### PR TITLE
remover linha do bootstrap para nao quebrar colunas no zoom

### DIFF
--- a/wp-content/themes/tema-ceus/classes/TemplateHierarchy/LoopUnidades/LoopUnidades.php
+++ b/wp-content/themes/tema-ceus/classes/TemplateHierarchy/LoopUnidades/LoopUnidades.php
@@ -14,7 +14,7 @@ class LoopUnidades extends Util
 
 	public function init(){
 		$container_geral_tags = array('div', 'div');
-		$container_geral_css = array('container-fluid', 'row');
+		$container_geral_css = array('container-fluid', '');
 		$this->abreContainer($container_geral_tags, $container_geral_css);
 
 		new LoopUnidadesCabecalho();


### PR DESCRIPTION
Remoção da linha (row) do Bootstrap na página de unidades para não deslocar as colunas quando aplicado a diminuição do zoom no navegador