### PR TITLE
Exibir CEUs em revisao pendente e redicionar para manutencao

### DIFF
--- a/wp-content/themes/tema-ceus/404.php
+++ b/wp-content/themes/tema-ceus/404.php
@@ -1,3 +1,14 @@
+<?php 
+    $actual_link = "https://$_SERVER[HTTP_HOST]$_SERVER[REQUEST_URI]";
+    
+    $validade = 'unidade';
+    $url = get_home_url() . "/conteudo-em-manutencao";
+
+    if (strpos($actual_link, $validade) !== false) {
+        wp_redirect( $url );
+        exit;
+    } 
+?>
 <?php get_header() ?>
 <section class="container fundo-branco">
     <?php

--- a/wp-content/themes/tema-ceus/classes/ModelosDePaginas/PaginaUnidades/PaginaUnidades.php
+++ b/wp-content/themes/tema-ceus/classes/ModelosDePaginas/PaginaUnidades/PaginaUnidades.php
@@ -90,7 +90,8 @@ class PaginaUnidades extends ArchiveContato
                                     'posts_per_page' => -1,
                                     'orderby' => 'title',
                                     'order' => 'ASC',
-                                    'post__not_in' => array(31244),                                    
+                                    'post__not_in' => array(31244),
+									'post_status' => array('publish', 'pending'),
 
                                 );
                                 $currentPage = get_the_permalink();
@@ -131,6 +132,7 @@ class PaginaUnidades extends ArchiveContato
 			'orderby' => 'title',
 			'order' => 'ASC',
 			'post__not_in' => array(34180, 31675),
+			'post_status' => array('publish', 'pending'),
 		);
 
 		$todasUnidades = new \WP_Query( $argsUnidades );

--- a/wp-content/themes/tema-ceus/classes/ModelosDePaginas/PaginaUnidades/PaginaUnidadesMapa.php
+++ b/wp-content/themes/tema-ceus/classes/ModelosDePaginas/PaginaUnidades/PaginaUnidadesMapa.php
@@ -67,7 +67,8 @@ class PaginaUnidadesMapa
                                     'posts_per_page' => -1,
                                     'orderby' => 'title',
                                     'order' => 'ASC',
-                                    'post__not_in' => array(31244),                                    
+                                    'post__not_in' => array(31244),
+                                    'post_status' => array('publish', 'pending'),                                  
 
                                 );
                                 $currentPage = get_the_permalink();
@@ -120,7 +121,8 @@ class PaginaUnidadesMapa
                             'post__not_in' => array(31244, 31675),
                             'order' => 'ASC',
                             'orderby' => 'title',
-                            'posts_per_page' => -1,                            
+                            'posts_per_page' => -1,
+                            'post_status' => array('publish', 'pending'),                        
                         );
 
                         if($_GET['idUnidade'] && $_GET['idUnidade'] != ''){

--- a/wp-content/themes/tema-ceus/footer.php
+++ b/wp-content/themes/tema-ceus/footer.php
@@ -249,6 +249,21 @@
         
     </script>
 
+<?php
+    $idUnidade = $_GET['idUnidade'];
+    $latitude = get_group_field( 'informacoes_basicas', 'latitude', $idUnidade );
+    $longitude = get_group_field( 'informacoes_basicas', 'longitude', $idUnidade );
+    
+    if (get_post_status($idUnidade) === 'pending') {
+        // Obtém o valor de um campo do ACF
+        //$latitude = get_field('informacoes_basicas_latitute', $idUnidade);
+    }
+
+    echo '<pre>';
+    print_r($latitude);
+    echo '</pre>';
+?>
+
 <?php if(is_page()) : ?>
     <script type="text/javascript">
 
@@ -261,6 +276,8 @@
             $idUnidade = $_GET['idUnidade'];
             $latitude = get_group_field( 'informacoes_basicas', 'latitude', $idUnidade );
             $longitude = get_group_field( 'informacoes_basicas', 'longitude', $idUnidade );
+
+            
             ?>
             var INITIAL_LNG = <?= $longitude ?>;
             var INITIAL_LAT = <?= $latitude; ?>;

--- a/wp-content/themes/tema-ceus/functions.php
+++ b/wp-content/themes/tema-ceus/functions.php
@@ -1329,7 +1329,8 @@ function get_unidades(){
 	$args = array(
 		'post_type' => 'unidade',
 		'post__not_in' => array(31244, 31675),
-		'posts_per_page' => -1
+		'posts_per_page' => -1,
+		'post_status' => array('publish', 'pending'),
 	);
 
 	if($_GET['idUnidade'] && $_GET['idUnidade'] != ''){
@@ -1396,7 +1397,8 @@ function data_fetch(){
 	$the_query = new WP_Query( array( 'posts_per_page' => 10,
 									  'post_status' => 'publish',
 									  'cc_search_post_title' => esc_attr( $_POST['keyword'] ), 
-									  'post_type' => 'unidade' ) );
+									  'post_type' => 'unidade',
+									  'post_status' => array('publish', 'pending'), ) );
 	remove_filter( 'posts_where', 'cc_post_title_filter', 10 );
 
     if( $the_query->have_posts() ) :
@@ -1926,7 +1928,8 @@ function filtering_unidade($post_type){
 			'orderby'	=> 'title',
 			'order'	=> 'ASC',
 			'meta_key' => '',
-			'meta_value' => '',		
+			'meta_value' => '',
+			'post_status' => array('publish', 'pending'),
 		) );
 
 		
@@ -2339,3 +2342,16 @@ function acf_validate_data( $valid, $value, $field, $input ) {
 
 	return $valid;
 }
+
+function unidade_pending_review_redirect(){
+	$user = wp_get_current_user();
+	$id = get_the_id();
+	if(get_post_status ( get_the_id() ) == 'pending'){
+		if (!is_user_logged_in() && !$user->roles[0] == 'administrator' ) {
+			$url = get_home_url() . "/conteudo-em-manutencao";
+			wp_redirect( $url );
+        	exit;
+		}
+	}
+}
+add_action('template_redirect', 'unidade_pending_review_redirect');


### PR DESCRIPTION
- Na página de Unidade e Mapa de Unidades exibir os CEUs que estão com status de revisão pendente;
- Redirecionar os usuários caso a unidade esteja como pendente para uma página de aviso sobre a manutenção do conteúdo da unidade.